### PR TITLE
add devise helpers to test_helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,3 +18,6 @@ class ActiveSupport::TestCase
   include FactoryGirl::Syntax::Methods
 end
 
+class ActionController::TestCase
+  include Devise::TestHelpers
+end


### PR DESCRIPTION
another small PR, I missed that the devise helpers weren't added when devise was initially added. this fixes that omission